### PR TITLE
[Bug] Change query and headers to collection of keyvaluepair

### DIFF
--- a/RestSharp.Easy.Console/Program.cs
+++ b/RestSharp.Easy.Console/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Serilog;
 using Serilog.Builder;
 using Serilog.Builder.Models;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 
@@ -33,6 +34,16 @@ namespace RestSharp.Easy.Console
                 .GetAwaiter().GetResult();
 
             var result2 = client.SendRequest<dynamic>(HttpMethod.Post, "restsharp-easy", body);
+
+            var query3 = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("page", "1"),
+                new KeyValuePair<string, string>("size", "10"),
+                new KeyValuePair<string, string>("ids", "1"),
+                new KeyValuePair<string, string>("ids", "2"),
+            };
+
+            var result3 = client.SendRequest<dynamic>(HttpMethod.Post, "restsharp-easy", body, query: query3);
 
             Thread.Sleep(5000);
         }

--- a/RestSharp.Easy/EasyRestClient.cs
+++ b/RestSharp.Easy/EasyRestClient.cs
@@ -7,6 +7,7 @@ using Serilog.Events;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -81,7 +82,7 @@ namespace RestSharp.Easy
             this.AddAuthorization($"Basic {basic}");
         }
 
-        public BaseResponse<TSuccess, TError> SendRequest<TSuccess, TError>(HttpMethod method, string endpoint, object body = null, IDictionary<string, string> query = null, IDictionary<string, string> headers = null)
+        public BaseResponse<TSuccess, TError> SendRequest<TSuccess, TError>(HttpMethod method, string endpoint, object body = null, ICollection<KeyValuePair<string, string>> query = null, ICollection<KeyValuePair<string, string>> headers = null)
             where TSuccess : class, new()
             where TError : class, new()
         {
@@ -89,7 +90,7 @@ namespace RestSharp.Easy
                 .GetAwaiter().GetResult();
         }
 
-        public async Task<BaseResponse<TSuccess, TError>> SendRequestAsync<TSuccess, TError>(HttpMethod method, string endpoint, object body = null, IDictionary<string, string> query = null, IDictionary<string, string> headers = null)
+        public async Task<BaseResponse<TSuccess, TError>> SendRequestAsync<TSuccess, TError>(HttpMethod method, string endpoint, object body = null, ICollection<KeyValuePair<string, string>> query = null, ICollection<KeyValuePair<string, string>> headers = null)
             where TSuccess : class, new()
             where TError : class, new()
         {
@@ -132,12 +133,12 @@ namespace RestSharp.Easy
             return response;
         }
 
-        public BaseResponse<TSuccess> SendRequest<TSuccess>(HttpMethod method, string endpoint, object body = null, IDictionary<string, string> query = null, IDictionary<string, string> headers = null) where TSuccess : class, new()
+        public BaseResponse<TSuccess> SendRequest<TSuccess>(HttpMethod method, string endpoint, object body = null, ICollection<KeyValuePair<string, string>> query = null, ICollection<KeyValuePair<string, string>> headers = null) where TSuccess : class, new()
         {
             return this.SendRequest<TSuccess, dynamic>(method, endpoint, body, query, headers);
         }
 
-        public async Task<BaseResponse<TSuccess>> SendRequestAsync<TSuccess>(HttpMethod method, string endpoint, object body = null, IDictionary<string, string> query = null, IDictionary<string, string> headers = null) where TSuccess : class, new()
+        public async Task<BaseResponse<TSuccess>> SendRequestAsync<TSuccess>(HttpMethod method, string endpoint, object body = null, ICollection<KeyValuePair<string, string>> query = null, ICollection<KeyValuePair<string, string>> headers = null) where TSuccess : class, new()
         {
             return await this.SendRequestAsync<TSuccess, dynamic>(method, endpoint, body, query, headers);
         }

--- a/RestSharp.Easy/Interfaces/IEasyRestClient.cs
+++ b/RestSharp.Easy/Interfaces/IEasyRestClient.cs
@@ -18,20 +18,20 @@ namespace RestSharp.Easy.Interfaces
         void AddBasic(string username, string password);
 
         BaseResponse<TSuccess, TError> SendRequest<TSuccess, TError>(
-            HttpMethod method, 
-            string endpoint, 
-            object body = null, 
-            IDictionary<string, string> query = null, 
-            IDictionary<string, string> headers = null)
-               where TSuccess : class, new() 
+            HttpMethod method,
+            string endpoint,
+            object body = null,
+            ICollection<KeyValuePair<string, string>> query = null,
+            ICollection<KeyValuePair<string, string>> headers = null)
+               where TSuccess : class, new()
                where TError : class, new();
 
         Task<BaseResponse<TSuccess, TError>> SendRequestAsync<TSuccess, TError>(
             HttpMethod method,
             string endpoint,
             object body = null,
-            IDictionary<string, string> query = null,
-            IDictionary<string, string> headers = null)
+            ICollection<KeyValuePair<string, string>> query = null,
+            ICollection<KeyValuePair<string, string>> headers = null)
                where TSuccess : class, new()
                where TError : class, new();
 
@@ -39,16 +39,16 @@ namespace RestSharp.Easy.Interfaces
            HttpMethod method,
            string endpoint,
            object body = null,
-           IDictionary<string, string> query = null,
-           IDictionary<string, string> headers = null)
+           ICollection<KeyValuePair<string, string>> query = null,
+           ICollection<KeyValuePair<string, string>> headers = null)
               where TSuccess : class, new();
 
         Task<BaseResponse<TSuccess>> SendRequestAsync<TSuccess>(
             HttpMethod method,
             string endpoint,
             object body = null,
-            IDictionary<string, string> query = null,
-            IDictionary<string, string> headers = null)
+            ICollection<KeyValuePair<string, string>> query = null,
+            ICollection<KeyValuePair<string, string>> headers = null)
                where TSuccess : class, new();
     }
 }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Changing the type of parameters: query and headers of methods SendRequest and SendRequestAsync. 

**This change break current compatibility. So, who update the version need convert dictionary to collection of keyvaluepair.**

### Why?

Because using dictionary not is possible has keys duplicates. So, if I need a query with the same parameters below I can't:

page: 1,
ids: 10,
ids: 20

### How?

Changing Dictionary<string, string> to ICollection<KeyValuePair<string, string>>

### Attachments (if appropriate)

Result of execution of program after change.
![evidence](https://user-images.githubusercontent.com/10949463/101493598-0a1afe80-3945-11eb-8b62-4cfa4e39fb81.png)
